### PR TITLE
Home 기능 추가

### DIFF
--- a/InMyMemory.xctestplan
+++ b/InMyMemory.xctestplan
@@ -43,6 +43,13 @@
         "identifier" : "MemoryRecordPresentationTests",
         "name" : "MemoryRecordPresentationTests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "HomePresentationTests",
+        "name" : "HomePresentationTests"
+      }
     }
   ],
   "version" : 1

--- a/InMyMemory/Data/Sources/Repositories/TodoRepository.swift
+++ b/InMyMemory/Data/Sources/Repositories/TodoRepository.swift
@@ -36,7 +36,7 @@ public final class TodoRepository: TodoRepositoryInterface {
         let predicate: Predicate<TodoModel> = #Predicate { model in
             model.date > date
         }
-        let sortBy: SortDescriptor<TodoModel> = .init(\.updatedAt, order: .forward)
+        let sortBy: SortDescriptor<TodoModel> = .init(\.date, order: .forward)
         return storage.read(predicate: predicate, sortBy: [sortBy])
             .map { $0.map { $0.toEntity() }}
     }
@@ -45,7 +45,7 @@ public final class TodoRepository: TodoRepositoryInterface {
         let predicate: Predicate<TodoModel> = #Predicate { model in
             return model.date >= greaterOrEqualDate && model.date < lessDate
         }
-        let sortBy: SortDescriptor<TodoModel> = .init(\.updatedAt, order: .forward)
+        let sortBy: SortDescriptor<TodoModel> = .init(\.date, order: .forward)
         return storage.read(predicate: predicate, sortBy: [sortBy])
             .map { $0.map { $0.toEntity() }}
     }
@@ -54,14 +54,18 @@ public final class TodoRepository: TodoRepositoryInterface {
         let predicate: Predicate<TodoModel> = #Predicate { model in
             return model.note.contains(keyword)
         }
-        let sortBy: SortDescriptor<TodoModel> = .init(\.updatedAt, order: .forward)
+        let sortBy: SortDescriptor<TodoModel> = .init(\.date, order: .forward)
         return storage.read(predicate: predicate, sortBy: [sortBy])
             .map { $0.map { $0.toEntity() }}
     }
     
     public func update(todo: Todo) -> Single<Void> {
+        let todoID = todo.id
+        let predicate: Predicate<TodoModel> = #Predicate { model in
+            return model.id == todoID
+        }
         let model = TodoModel(todo: todo)
-        return storage.insert(model: model)
+        return storage.upsert(model: model, predicate: predicate)
     }
     
     public func delete(todo: Todo) -> Single<Void> {

--- a/InMyMemory/Domain/Package.swift
+++ b/InMyMemory/Domain/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "Domain",
+    platforms: [.iOS(.v17)],
     products: [
         .library(
             name: "Entities",

--- a/InMyMemory/Domain/Sources/Interfaces/UseCases/HomeUseCaseInterface.swift
+++ b/InMyMemory/Domain/Sources/Interfaces/UseCases/HomeUseCaseInterface.swift
@@ -13,4 +13,5 @@ public protocol HomeUseCaseInterface: AnyObject {
     func fetchLastSevenDaysMemories() -> Single<[Memory]>
     func fetchCurrentWeekTodos() -> Single<[Todo]>
     func fetchLastSevenDaysEmotions() -> Single<[Emotion]>
+    func updateTodo(todo: Todo) -> Single<Void>
 }

--- a/InMyMemory/Domain/Sources/UseCases/HomeUseCase.swift
+++ b/InMyMemory/Domain/Sources/UseCases/HomeUseCase.swift
@@ -34,7 +34,8 @@ public final class HomeUseCase: HomeUseCaseInterface {
     
     public func fetchCurrentWeekTodos() -> Single<[Todo]> {
         let sevenDaysAgo = Date().daysAgo(value: 7).clipDate()
-        return todoRepository.read(greaterThan: sevenDaysAgo)
+        let sevenDaysAfter = Date().daysAgo(value: -7).clipDate()
+        return todoRepository.read(greaterOrEqualThan: sevenDaysAgo, lessThan: sevenDaysAfter)
     }
     
     public func fetchLastSevenDaysEmotions() -> Single<[Emotion]> {

--- a/InMyMemory/Domain/Sources/UseCases/HomeUseCase.swift
+++ b/InMyMemory/Domain/Sources/UseCases/HomeUseCase.swift
@@ -42,4 +42,8 @@ public final class HomeUseCase: HomeUseCaseInterface {
         return emotionRepository.read(greaterThan: sevenDaysAgo)
     }
     
+    public func updateTodo(todo: Todo) -> Single<Void> {
+        return todoRepository.update(todo: todo)
+    }
+    
 }

--- a/InMyMemory/Presentation/Package.swift
+++ b/InMyMemory/Presentation/Package.swift
@@ -24,6 +24,10 @@ let package = Package(
             targets: ["HomePresentation"]
         ),
         .library(
+            name: "HomeTestSupport",
+            targets: ["HomeTestSupport"]
+        ),
+        .library(
             name: "RecordInterface",
             targets: ["RecordInterface"]
         ),
@@ -163,6 +167,17 @@ let package = Package(
                 "CalendarInterface",
                 "MemoryDetailInterface",
                 "DesignKit",
+                "HomeInterface",
+                .product(name: "CoreKit", package: "Shared"),
+                .product(name: "Entities", package: "Domain"),
+                .product(name: "Interfaces", package: "Domain"),
+            ]
+        ),
+        .target(
+            name: "HomeTestSupport",
+            dependencies: [
+                "RxSwift",
+                "BasePresentation",
                 "HomeInterface",
                 .product(name: "CoreKit", package: "Shared"),
                 .product(name: "Entities", package: "Domain"),

--- a/InMyMemory/Presentation/Package.swift
+++ b/InMyMemory/Presentation/Package.swift
@@ -435,6 +435,19 @@ let package = Package(
             ]
         ),
         .testTarget(
+            name: "HomePresentationTests",
+            dependencies: [
+                "PresentationTestSupport",
+                "HomeTestSupport",
+                "HomePresentation",
+                .product(name: "CoreKit", package: "Shared"),
+                .product(name: "Entities", package: "Domain"),
+                .product(name: "Interfaces", package: "Domain"),
+                "Quick",
+                "Nimble"
+            ]
+        ),
+        .testTarget(
             name: "CalendarPresentationTests",
             dependencies: [
                 "PresentationTestSupport",

--- a/InMyMemory/Presentation/Package.swift
+++ b/InMyMemory/Presentation/Package.swift
@@ -159,6 +159,7 @@ let package = Package(
                 "BasePresentation",
                 "RecordInterface",
                 "EmotionRecordInterface",
+                "MemoryRecordInterface",
                 "CalendarInterface",
                 "MemoryDetailInterface",
                 "DesignKit",

--- a/InMyMemory/Presentation/Sources/HomePresentation/Emotion/Components/EmotionHomeRecordView.swift
+++ b/InMyMemory/Presentation/Sources/HomePresentation/Emotion/Components/EmotionHomeRecordView.swift
@@ -8,13 +8,15 @@
 import UIKit
 import BasePresentation
 import DesignKit
+import RxSwift
+import RxCocoa
 import SnapKit
 import Then
 
 final class EmotionHomeRecordView: BaseView {
     
     private let titleView = HomeTitleView()
-    private let recordButton = ActionButton()
+    fileprivate let recordButton = ActionButton()
     
     override func setupLayout() {
         addSubview(titleView)
@@ -44,4 +46,12 @@ final class EmotionHomeRecordView: BaseView {
         }
     }
     
+}
+
+extension Reactive where Base: EmotionHomeRecordView {
+    
+    var recordTap: ControlEvent<Void> {
+        let source = base.recordButton.rx.tap
+        return ControlEvent(events: source)
+    }
 }

--- a/InMyMemory/Presentation/Sources/HomePresentation/Emotion/EmotionHomeViewController.swift
+++ b/InMyMemory/Presentation/Sources/HomePresentation/Emotion/EmotionHomeViewController.swift
@@ -31,7 +31,7 @@ final class EmotionHomeViewController: UIViewController {
     private let scrollView = UIScrollView()
     private let stackView = UIStackView()
     
-    private let recordView = EmotionHomeRecordView()
+    fileprivate let recordView = EmotionHomeRecordView()
     private let pastWeekView = EmotionHomePastWeekView()
     fileprivate let graphView = EmotionHomeGraphView()
     
@@ -84,6 +84,10 @@ final class EmotionHomeViewController: UIViewController {
 }
 
 extension Reactive where Base: EmotionHomeViewController {
+    
+    var recordTap: ControlEvent<Void> {
+        return base.recordView.rx.recordTap
+    }
     
     var informationTap: ControlEvent<Void> {
         let source = base.graphView.rx.informationTap

--- a/InMyMemory/Presentation/Sources/HomePresentation/HomeReactor.swift
+++ b/InMyMemory/Presentation/Sources/HomePresentation/HomeReactor.swift
@@ -20,6 +20,7 @@ enum HomeAction {
     case refreshMemory
     case recordDidTap
     case memoryRecordDidTap
+    case emotionRecordDidTap
     case calendarDidTap
     case memoryDidTap(UUID)
 }
@@ -79,6 +80,10 @@ final class HomeReactor: Reactor, Stepper {
             
         case .memoryRecordDidTap:
             steps.accept(AppStep.memoryRecordIsRequired(Date()))
+            return .empty()
+            
+        case .emotionRecordDidTap:
+            steps.accept(AppStep.emotionRecordIsRequired(Date()))
             return .empty()
             
         case .calendarDidTap:

--- a/InMyMemory/Presentation/Sources/HomePresentation/HomeReactor.swift
+++ b/InMyMemory/Presentation/Sources/HomePresentation/HomeReactor.swift
@@ -23,17 +23,20 @@ enum HomeAction {
     case emotionRecordDidTap
     case calendarDidTap
     case memoryDidTap(UUID)
+    case todoDidTap(UUID)
 }
 
 struct HomeState {
     var isLoading: Bool
     var emotionViewModel: EmotionHomeViewModel?
-    var memoryViewModel: MemoryHomeViewModel?
+    var memoryPastWeekViewModel: MemoryHomePastWeekViewModel?
+    var todoViewModel: MemoryHomeTodoViewModel?
 }
 
 enum HomeMutation {
     case setLoading(Bool)
-    case setMemories([Memory], [Todo])
+    case setMemories([Memory])
+    case setTodos([Todo])
     case setEmotions([Emotion])
 }
 
@@ -93,6 +96,14 @@ final class HomeReactor: Reactor, Stepper {
         case .memoryDidTap(let memoryID):
             steps.accept(AppStep.memoryDetailIsRequired(memoryID))
             return .empty()
+            
+        case .todoDidTap(let todoID):
+            return .concat([
+                updateTodo(todoID: todoID),
+                .just(.setLoading(true)),
+                refreshTodos(),
+                .just(.setLoading(false))
+            ])
         }
     }
     
@@ -102,12 +113,11 @@ final class HomeReactor: Reactor, Stepper {
         case .setLoading(let isLoading):
             newState.isLoading = isLoading
             
-        case .setMemories(let memories, let todos):
-            let memoryViewModel = MemoryHomeViewModel(
-                pastWeekViewModel: makeWeekViewModel(memories),
-                todoViewModel: makeTodoViewModel(todos)
-            )
-            newState.memoryViewModel = memoryViewModel
+        case .setMemories(let memories):
+            newState.memoryPastWeekViewModel = makeWeekViewModel(memories)
+            
+        case .setTodos(let todos):
+            newState.todoViewModel = makeTodoViewModel(todos)
             
         case .setEmotions(let emotions):
             let emotionViewModel = EmotionHomeViewModel(
@@ -123,20 +133,26 @@ final class HomeReactor: Reactor, Stepper {
     private func refresh() -> Observable<HomeMutation> {
         return Observable.merge([
             refreshMemories(),
+            refreshTodos(),
             refreshEmotions()
         ])
     }
     
     private func refreshMemories() -> Observable<HomeMutation> {
-        return Observable.zip(
-            useCase.fetchLastSevenDaysMemories().asObservable(),
-            useCase.fetchCurrentWeekTodos().asObservable()
-        ).map { Mutation.setMemories($0.0, $0.1) }
+        return useCase.fetchLastSevenDaysMemories()
+            .map(Mutation.setMemories)
+            .asObservable()
     }
     
     private func refreshEmotions() -> Observable<HomeMutation> {
         return useCase.fetchLastSevenDaysEmotions()
-            .map { Mutation.setEmotions($0) }
+            .map(Mutation.setEmotions)
+            .asObservable()
+    }
+    
+    private func refreshTodos() -> Observable<HomeMutation> {
+        return useCase.fetchCurrentWeekTodos()
+            .map(Mutation.setTodos)
             .asObservable()
     }
     
@@ -179,9 +195,26 @@ final class HomeReactor: Reactor, Stepper {
     
     private func makeTodoViewModel(_ todos: [Todo]) -> MemoryHomeTodoViewModel {
         let items: [MemoryHomeTodoContentViewModel] = todos.prefix(10).map {
-            .init(todo: $0.note, isChecked: $0.isCompleted)
+            .init(id: $0.id, todo: $0.note, isChecked: $0.isCompleted, date: $0.date)
         }
         return .init(items: items)
+    }
+    
+    private func updateTodo(todoID: UUID) -> Observable<Mutation> {
+        guard let todoModel = currentState.todoViewModel?.items.first(where: { $0.id == todoID }) else {
+            return .empty()
+        }
+        return .concat([
+            .just(.setLoading(true)),
+            useCase.updateTodo(todo: .init(
+                id: todoID,
+                note: todoModel.todo,
+                isCompleted: !todoModel.isChecked,
+                date: todoModel.date
+            ))
+            .map { .setLoading(false) }
+            .asObservable()
+        ])
     }
     
 }

--- a/InMyMemory/Presentation/Sources/HomePresentation/HomeReactor.swift
+++ b/InMyMemory/Presentation/Sources/HomePresentation/HomeReactor.swift
@@ -19,6 +19,7 @@ enum HomeAction {
     case refreshEmotion
     case refreshMemory
     case recordDidTap
+    case memoryRecordDidTap
     case calendarDidTap
     case memoryDidTap(UUID)
 }
@@ -74,6 +75,10 @@ final class HomeReactor: Reactor, Stepper {
             ])
         case .recordDidTap:
             steps.accept(AppStep.recordIsRequired(Date()))
+            return .empty()
+            
+        case .memoryRecordDidTap:
+            steps.accept(AppStep.memoryRecordIsRequired(Date()))
             return .empty()
             
         case .calendarDidTap:

--- a/InMyMemory/Presentation/Sources/HomePresentation/HomeViewController.swift
+++ b/InMyMemory/Presentation/Sources/HomePresentation/HomeViewController.swift
@@ -124,7 +124,12 @@ final class HomeViewController: BaseViewController<HomeReactor> {
             .disposed(by: disposeBag)
         
         memoryViewController.rx.detailID
-            .map { Reactor.Action.memoryDidTap($0) }
+            .map(Reactor.Action.memoryDidTap)
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        memoryViewController.rx.todoID
+            .map(Reactor.Action.todoDidTap)
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
@@ -139,8 +144,12 @@ final class HomeViewController: BaseViewController<HomeReactor> {
             .bind(to: emotionViewController.viewModelBinder)
             .disposed(by: disposeBag)
         
-        reactor.state.compactMap(\.memoryViewModel)
-            .bind(to: memoryViewController.viewModelBinder)
+        reactor.state.compactMap(\.memoryPastWeekViewModel)
+            .bind(to: memoryViewController.pastWeekViewModelBinder)
+            .disposed(by: disposeBag)
+        
+        reactor.state.compactMap(\.todoViewModel)
+            .bind(to: memoryViewController.todoViewModelBinder)
             .disposed(by: disposeBag)
     }
     

--- a/InMyMemory/Presentation/Sources/HomePresentation/HomeViewController.swift
+++ b/InMyMemory/Presentation/Sources/HomePresentation/HomeViewController.swift
@@ -118,6 +118,11 @@ final class HomeViewController: BaseViewController<HomeReactor> {
             .bind(to: emotionInformationTapBinder)
             .disposed(by: disposeBag)
         
+        emotionViewController.rx.recordTap
+            .map { Reactor.Action.emotionRecordDidTap }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         memoryViewController.rx.detailID
             .map { Reactor.Action.memoryDidTap($0) }
             .bind(to: reactor.action)

--- a/InMyMemory/Presentation/Sources/HomePresentation/HomeViewController.swift
+++ b/InMyMemory/Presentation/Sources/HomePresentation/HomeViewController.swift
@@ -122,6 +122,11 @@ final class HomeViewController: BaseViewController<HomeReactor> {
             .map { Reactor.Action.memoryDidTap($0) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
+        
+        memoryViewController.rx.recordTap
+            .map { Reactor.Action.memoryRecordDidTap }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
     }
     
     private func bindState(_ reactor: Reactor) {

--- a/InMyMemory/Presentation/Sources/HomePresentation/Memory/Components/MemoryHomeRecordView.swift
+++ b/InMyMemory/Presentation/Sources/HomePresentation/Memory/Components/MemoryHomeRecordView.swift
@@ -8,13 +8,15 @@
 import UIKit
 import BasePresentation
 import DesignKit
+import RxSwift
+import RxCocoa
 import SnapKit
 import Then
 
 final class MemoryHomeRecordView: BaseView {
     
     private let titleView = HomeTitleView()
-    private let recordButton = ActionButton()
+    fileprivate let recordButton = ActionButton()
     
     override func setupLayout() {
         addSubview(titleView)
@@ -42,6 +44,15 @@ final class MemoryHomeRecordView: BaseView {
             $0.setTitle("기록하기", for: .normal)
             $0.layer.cornerRadius = 20
         }
+    }
+    
+}
+
+extension Reactive where Base: MemoryHomeRecordView {
+    
+    var recordTap: ControlEvent<Void> {
+        let source = base.recordButton.rx.tap
+        return ControlEvent(events: source)
     }
     
 }

--- a/InMyMemory/Presentation/Sources/HomePresentation/Memory/Components/MemoryHomeTodoContentView.swift
+++ b/InMyMemory/Presentation/Sources/HomePresentation/Memory/Components/MemoryHomeTodoContentView.swift
@@ -12,8 +12,10 @@ import SnapKit
 import Then
 
 struct MemoryHomeTodoContentViewModel {
+    let id: UUID
     let todo: String
     let isChecked: Bool
+    let date: Date
 }
 
 final class MemoryHomeTodoContentView: BaseView {

--- a/InMyMemory/Presentation/Sources/HomePresentation/Memory/Components/MemoryHomeTodoView.swift
+++ b/InMyMemory/Presentation/Sources/HomePresentation/Memory/Components/MemoryHomeTodoView.swift
@@ -8,6 +8,9 @@
 import UIKit
 import BasePresentation
 import DesignKit
+import RxSwift
+import RxCocoa
+import RxRelay
 import SnapKit
 import Then
 
@@ -19,6 +22,7 @@ final class MemoryHomeTodoView: BaseView {
     
     private let titleView = HomeTitleView()
     private let stackView = UIStackView()
+    fileprivate let tapRelay = PublishRelay<UUID>()
     
     func setup(model: MemoryHomeTodoViewModel) {
         stackView.subviews.forEach { $0.removeFromSuperview() }
@@ -31,6 +35,10 @@ final class MemoryHomeTodoView: BaseView {
             view.snp.makeConstraints { make in
                 make.height.equalTo(40)
             }
+            view.rx.recognizedTap
+                .map { item.id }
+                .bind(to: tapRelay)
+                .disposed(by: disposeBag)
         }
     }
     
@@ -60,6 +68,15 @@ final class MemoryHomeTodoView: BaseView {
             $0.distribution = .equalSpacing
             $0.spacing = 10
         }
+    }
+    
+}
+
+extension Reactive where Base: MemoryHomeTodoView {
+    
+    var todoID: ControlEvent<UUID> {
+        let source = base.tapRelay
+        return ControlEvent(events: source)
     }
     
 }

--- a/InMyMemory/Presentation/Sources/HomePresentation/Memory/MemoryHomeViewController.swift
+++ b/InMyMemory/Presentation/Sources/HomePresentation/Memory/MemoryHomeViewController.swift
@@ -34,7 +34,7 @@ final class MemoryHomeViewController: UIViewController {
     private let scrollView = UIScrollView()
     private let stackView = UIStackView()
     
-    private let recordView = MemoryHomeRecordView()
+    fileprivate let recordView = MemoryHomeRecordView()
     private let pastWeekView = MemoryHomePastWeekView()
     private let todoView = MemoryHomeTodoView()
     
@@ -98,6 +98,10 @@ extension Reactive where Base: MemoryHomeViewController {
     var detailID: ControlEvent<UUID> {
         let source = base.detailTapRelay
         return ControlEvent(events: source)
+    }
+    
+    var recordTap: ControlEvent<Void> {
+        return base.recordView.rx.recordTap
     }
     
 }

--- a/InMyMemory/Presentation/Sources/HomePresentation/Memory/MemoryHomeViewController.swift
+++ b/InMyMemory/Presentation/Sources/HomePresentation/Memory/MemoryHomeViewController.swift
@@ -15,20 +15,22 @@ import RxRelay
 import SnapKit
 import Then
 
-struct MemoryHomeViewModel {
-    let pastWeekViewModel: MemoryHomePastWeekViewModel
-    let todoViewModel: MemoryHomeTodoViewModel
-}
-
 final class MemoryHomeViewController: UIViewController {
     
-    var viewModelBinder: Binder<MemoryHomeViewModel> {
+    var pastWeekViewModelBinder: Binder<MemoryHomePastWeekViewModel> {
         return Binder(self) { this, viewModel in
-            this.pastWeekView.setup(model: viewModel.pastWeekViewModel)
-            this.todoView.setup(model: viewModel.todoViewModel)
+            this.pastWeekView.setup(model: viewModel)
         }
     }
+    
+    var todoViewModelBinder: Binder<MemoryHomeTodoViewModel> {
+        return Binder(self) { this, viewModel in
+            this.todoView.setup(model: viewModel)
+        }
+    }
+    
     fileprivate let detailTapRelay = PublishRelay<UUID>()
+    fileprivate let todoTapRelay = PublishRelay<UUID>()
     private let disposeBag = DisposeBag()
     
     private let scrollView = UIScrollView()
@@ -89,6 +91,10 @@ final class MemoryHomeViewController: UIViewController {
         pastWeekView.rx.detailID
             .bind(to: detailTapRelay)
             .disposed(by: disposeBag)
+        
+        todoView.rx.todoID
+            .bind(to: todoTapRelay)
+            .disposed(by: disposeBag)
     }
     
 }
@@ -97,6 +103,11 @@ extension Reactive where Base: MemoryHomeViewController {
     
     var detailID: ControlEvent<UUID> {
         let source = base.detailTapRelay
+        return ControlEvent(events: source)
+    }
+    
+    var todoID: ControlEvent<UUID> {
+        let source = base.todoTapRelay
         return ControlEvent(events: source)
     }
     

--- a/InMyMemory/Presentation/Sources/HomeTestSupport/HomeUseCaesMock.swift
+++ b/InMyMemory/Presentation/Sources/HomeTestSupport/HomeUseCaesMock.swift
@@ -1,0 +1,46 @@
+//
+//  HomeUseCaesMock.swift
+//
+//
+//  Created by 홍성준 on 1/19/24.
+//
+
+import Foundation
+import Interfaces
+import Entities
+import RxSwift
+
+public final class HomeUseCaesMock: HomeUseCaseInterface {
+    
+    public init() {}
+    
+    public var fetchLastSevenDaysMemoriesCallCount = 0
+    public var fetchLastSevenDaysMemoriesMemories: [Memory] = []
+    public func fetchLastSevenDaysMemories() -> Single<[Memory]> {
+        fetchLastSevenDaysMemoriesCallCount += 1
+        return .just(fetchLastSevenDaysMemoriesMemories)
+    }
+    
+    public var fetchCurrentWeekTodosCallCount = 0
+    public var fetchCurrentWeekTodosTodos: [Todo] = []
+    public func fetchCurrentWeekTodos() -> Single<[Todo]> {
+        fetchCurrentWeekTodosCallCount += 1
+        return .just(fetchCurrentWeekTodosTodos)
+    }
+    
+    public var fetchLastSevenDaysEmotionsCallCount = 0
+    public var fetchLastSevenDaysEmotionsEmotions: [Emotion] = []
+    public func fetchLastSevenDaysEmotions() -> RxSwift.Single<[Emotion]> {
+        fetchLastSevenDaysEmotionsCallCount += 1
+        return .just(fetchLastSevenDaysEmotionsEmotions)
+    }
+    
+    public var updateTodotodoCallCount = 0
+    public var updateTodotodoTodo: Todo?
+    public func updateTodo(todo: Todo) -> Single<Void> {
+        updateTodotodoCallCount += 1
+        updateTodotodoTodo = todo
+        return .just(())
+    }
+    
+}

--- a/InMyMemory/Presentation/Tests/HomePresentationTests/HomeReactorTests.swift
+++ b/InMyMemory/Presentation/Tests/HomePresentationTests/HomeReactorTests.swift
@@ -1,0 +1,279 @@
+//
+//  HomeReactorTests.swift
+//
+//
+//  Created by 홍성준 on 1/19/24.
+//
+
+@testable import HomePresentation
+import PresentationTestSupport
+import HomeTestSupport
+import Entities
+import Interfaces
+import CoreKit
+import BasePresentation
+import XCTest
+import Quick
+import Nimble
+import ReactorKit
+import RxSwift
+import RxRelay
+import RxFlow
+
+final class HomeReactorTests: QuickSpec {
+    
+    override class func spec() {
+        var sut: HomeReactor!
+        var useCase: HomeUseCaesMock!
+        var disposeBag: DisposeBag!
+        var stepBinder: StepBinder!
+        
+        describe("HomeReactor 테스트") {
+            beforeEach {
+                useCase = .init()
+                disposeBag = .init()
+                stepBinder = .init()
+                sut = .init(useCase: useCase)
+                sut.steps
+                    .bind(to: stepBinder.step)
+                    .disposed(by: disposeBag)
+            }
+            
+            context("refresh가 호출되면") {
+                let todos: [Todo] = [
+                    .init(id: UUID(), note: "", isCompleted: false, date: Date()),
+                    .init(id: UUID(), note: "", isCompleted: false, date: Date()),
+                    .init(id: UUID(), note: "", isCompleted: false, date: Date()),
+                    .init(id: UUID(), note: "", isCompleted: false, date: Date())
+                ]
+                let memories: [Memory] = [
+                    .init(id: UUID(), images: [], note: "", date: Date()),
+                    .init(id: UUID(), images: [], note: "", date: Date()),
+                    .init(id: UUID(), images: [], note: "", date: Date()),
+                    .init(id: UUID(), images: [], note: "", date: Date()),
+                    .init(id: UUID(), images: [], note: "", date: Date())
+                ]
+                let emotions: [Emotion] = [
+                    .init(id: UUID(), note: "", emotionType: .bad, date: Date()),
+                    .init(id: UUID(), note: "", emotionType: .bad, date: Date()),
+                    .init(id: UUID(), note: "", emotionType: .bad, date: Date()),
+                    .init(id: UUID(), note: "", emotionType: .bad, date: Date()),
+                    .init(id: UUID(), note: "", emotionType: .good, date: Date()),
+                    .init(id: UUID(), note: "", emotionType: .soso, date: Date()),
+                ]
+                beforeEach {
+                    useCase.fetchCurrentWeekTodosTodos = todos
+                    useCase.fetchLastSevenDaysMemoriesMemories = memories
+                    useCase.fetchLastSevenDaysEmotionsEmotions = emotions
+                    sut.action.onNext(.refresh)
+                }
+                
+                it("Todo 정보를 불러온다") {
+                    expect(useCase.fetchCurrentWeekTodosCallCount) == 1
+                }
+                
+                it("Emotion 정보를 불러온다") {
+                    expect(useCase.fetchLastSevenDaysEmotionsCallCount) == 1
+                }
+                
+                it("Memory 정보를 불러온다") {
+                    expect(useCase.fetchLastSevenDaysMemoriesCallCount) == 1
+                }
+                
+                it("TodoViewModel이 설정된다") {
+                    let viewModel = try unwrap(sut.currentState.todoViewModel)
+                    expect(viewModel.items.map(\.id)) == todos.map(\.id)
+                }
+                
+                it("MemoryPastWeekViewModel이 설정된다") {
+                    let viewModel = try unwrap(sut.currentState.memoryPastWeekViewModel)
+                    expect(viewModel.items.map(\.id)) == memories.map(\.id)
+                }
+                
+                it("EmotionViewModel이 설정된다") {
+                    expect(sut.currentState.emotionViewModel) != nil
+                }
+                
+                context("Todo 정보가 있는 상태에서 todoDidTap이 호출되면") {
+                    beforeEach {
+                        useCase.fetchCurrentWeekTodosCallCount = 0
+                        let id = try unwrap(todos.first?.id)
+                        sut.action.onNext(.todoDidTap(id))
+                    }
+                    
+                    it("Todo 업데이트를 호출한다") {
+                        expect(useCase.updateTodotodoCallCount) == 1
+                    }
+                    
+                    it("Todo 정보를 불러온다") {
+                        expect(useCase.fetchCurrentWeekTodosCallCount) == 1
+                    }
+                }
+            }
+            
+            context("refreshEmotion이 호출되면") {
+                let emotions: [Emotion] = [
+                    .init(id: UUID(), note: "", emotionType: .bad, date: Date()),
+                    .init(id: UUID(), note: "", emotionType: .bad, date: Date()),
+                    .init(id: UUID(), note: "", emotionType: .bad, date: Date()),
+                    .init(id: UUID(), note: "", emotionType: .bad, date: Date()),
+                    .init(id: UUID(), note: "", emotionType: .good, date: Date()),
+                    .init(id: UUID(), note: "", emotionType: .soso, date: Date()),
+                ]
+                
+                beforeEach {
+                    useCase.fetchLastSevenDaysEmotionsEmotions = emotions
+                    sut.action.onNext(.refreshEmotion)
+                }
+                
+                it("Emotion 정보를 불러온다") {
+                    expect(useCase.fetchLastSevenDaysEmotionsCallCount) == 1
+                }
+                
+                it("EmotionViewModel이 설정된다") {
+                    expect(sut.currentState.emotionViewModel) != nil
+                }
+                
+                it("Todo 정보를 불러오지 않는다") {
+                    expect(useCase.fetchCurrentWeekTodosCallCount) == 0
+                    expect(sut.currentState.todoViewModel) == nil
+                }
+                
+                it("Memory 정보를 불러오지 않는다") {
+                    expect(useCase.fetchLastSevenDaysMemoriesCallCount) == 0
+                    expect(sut.currentState.memoryPastWeekViewModel) == nil
+                }
+            }
+            
+            context("refreshMemory이 호출되면") {
+                let memories: [Memory] = [
+                    .init(id: UUID(), images: [], note: "", date: Date()),
+                    .init(id: UUID(), images: [], note: "", date: Date()),
+                    .init(id: UUID(), images: [], note: "", date: Date()),
+                    .init(id: UUID(), images: [], note: "", date: Date()),
+                    .init(id: UUID(), images: [], note: "", date: Date())
+                ]
+                beforeEach {
+                    useCase.fetchLastSevenDaysMemoriesMemories = memories
+                    sut.action.onNext(.refreshMemory)
+                }
+                
+                it("Memory 정보를 불러온다") {
+                    expect(useCase.fetchLastSevenDaysMemoriesCallCount) == 1
+                }
+                
+                it("MemoryPastWeekViewModel이 설정된다") {
+                    let viewModel = try unwrap(sut.currentState.memoryPastWeekViewModel)
+                    expect(viewModel.items.map(\.id)) == memories.map(\.id)
+                }
+                
+                it("Emotion 정보를 불러오지 않는다") {
+                    expect(useCase.fetchLastSevenDaysEmotionsCallCount) == 0
+                    expect(sut.currentState.emotionViewModel) == nil
+                }
+                
+                it("Todo 정보를 불러오지 않는다") {
+                    expect(useCase.fetchCurrentWeekTodosCallCount) == 0
+                    expect(sut.currentState.todoViewModel) == nil
+                }
+            }
+            
+            context("recordDidTap이 호출되면") {
+                beforeEach {
+                    sut.action.onNext(.recordDidTap)
+                }
+                
+                it("recordIsRequired로 라우팅 된다.") {
+                    expect {
+                        let step = try unwrap(stepBinder.steps.last as? AppStep)
+                        guard case .recordIsRequired = step else {
+                            return .failed(reason: "올바르지 않은 라우팅")
+                        }
+                        return .succeeded
+                    }.to(succeed())
+                }
+            }
+            
+            context("memoryRecordDidTap이 호출되면") {
+                beforeEach {
+                    sut.action.onNext(.memoryRecordDidTap)
+                }
+                
+                it("memoryRecordIsRequired로 라우팅 된다.") {
+                    expect {
+                        let step = try unwrap(stepBinder.steps.last as? AppStep)
+                        guard case .memoryRecordIsRequired = step else {
+                            return .failed(reason: "올바르지 않은 라우팅")
+                        }
+                        return .succeeded
+                    }.to(succeed())
+                }
+            }
+            
+            context("emotionRecordDidTap이 호출되면") {
+                beforeEach {
+                    sut.action.onNext(.emotionRecordDidTap)
+                }
+                
+                it("emotionRecordIsRequired로 라우팅 된다.") {
+                    expect {
+                        let step = try unwrap(stepBinder.steps.last as? AppStep)
+                        guard case .emotionRecordIsRequired = step else {
+                            return .failed(reason: "올바르지 않은 라우팅")
+                        }
+                        return .succeeded
+                    }.to(succeed())
+                }
+            }
+            
+            context("calendarDidTap이 호출되면") {
+                beforeEach {
+                    sut.action.onNext(.calendarDidTap)
+                }
+                
+                it("calendarIsRequired로 라우팅 된다.") {
+                    expect {
+                        let step = try unwrap(stepBinder.steps.last as? AppStep)
+                        guard case .calendarIsRequired = step else {
+                            return .failed(reason: "올바르지 않은 라우팅")
+                        }
+                        return .succeeded
+                    }.to(succeed())
+                }
+            }
+            
+            context("memoryDidTap이 호출되면") {
+                let id = UUID()
+                beforeEach {
+                    sut.action.onNext(.memoryDidTap(id))
+                }
+                
+                it("memoryDetailIsRequired로 라우팅 된다.") {
+                    expect {
+                        let step = try unwrap(stepBinder.steps.last as? AppStep)
+                        guard case .memoryDetailIsRequired(let memoryID) = step else {
+                            return .failed(reason: "올바르지 않은 라우팅")
+                        }
+                        return memoryID == id ? .succeeded : .failed(reason: "올바르지 않은 ID")
+                    }.to(succeed())
+                }
+            }
+            
+            context("Todo 정보가 없는 상태에서 todoDidTap이 호출되면") {
+                let id = UUID()
+                beforeEach {
+                    sut.action.onNext(.todoDidTap(id))
+                }
+                
+                it("Todo 업데이트를 호출하지 않는다") {
+                    expect(useCase.updateTodotodoCallCount) == 0
+                }
+                
+                it("Todo 정보를 불러온다") {
+                    expect(useCase.fetchCurrentWeekTodosCallCount) == 1
+                }
+            }
+        }
+    }
+    
+}


### PR DESCRIPTION
## 🌁 연관 이슈
* close #76 

## ✅ 수정 내역
* 할일 업데이트 추가
* Memory, Emotion Record 라우팅 추가

## 📕 리뷰 노트
* 기존에 Memory를 새로고침을 Todo랑 같이 했는데 따로 분리하였음
* 할일 체크를 누를 때마다 변경되는 이슈가 있었음
  * 정렬을 updatedAt으로 해서 생긴 이슈
  * 값을 불러올 때 note로 정렬하도록 하였음
* 최근 7일 전부터의 할일을 불러오는데 너무 많은 것 같음
  * 오늘 기준으로 7일 전후 범위로 변경하였음
